### PR TITLE
Rolltablefixes 08

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,19 @@ Also recommended is the use of [better rolltables](https://github.com/ultrakorne
 
 ### Example of filled inventory
 On the left is the sheet of a token that was droped on the scene.
-The right sheet is directly from the actor.
+The right hand sheet is directly from the actor.
 
 ![image](https://github.com/DanielBoettner/fvtt-loot-populator-npc-5e/blob/master/SheetExample.png)
 
 ### Features
 
 Allows you to have automated random loot on NPCs when dropping them on the scene.
-If installed, it will make use of better rolltables.
+If installed and activated, it can make use of better rolltables.
 
 ### Compatibility:
-- Tested with FVTT v0.7.9 and the DND5E system only.
+- FoundryVTT v0.7.10
+- FoundryVTT v0.8.6+
+- Tested with DnD5e system only.
 
 ### Installation Instructions
 

--- a/module.json
+++ b/module.json
@@ -1,10 +1,10 @@
 {
 	"name": "lootpopulatornpc5e",
 	"title": "LootPopulator NPC 5e",
-	"description": "A module to auto populate loot on NPCs",
-	"version": "0.0.5",
+	"description": "A module to automatically populate loot on monsters and npcs when places on the map.",
+	"version": "0.1.0",
 	"minimumCoreVersion": "0.8.5",
-	"compatibleCoreVersion": "0.8.6",
+	"compatibleCoreVersion": "0.8.7",
 	"author": "Daniel Böttner",
 	"systems": ["dnd5e"],
 	"includes": [

--- a/scripts/populateLoot.js
+++ b/scripts/populateLoot.js
@@ -54,6 +54,17 @@ export class LootPopulator {
                     newItem = await items.getEntity(rollResult.results[0].data.resultId);
                 }
 
+								if (newItem instanceof RollTable){
+									let subTableResults  = await newItem.roll();
+
+									if(subTableResults.results[0].data.collection === "Item"){
+										newItem = game.items.get(subTableResults.results[0].data.resultId);
+									} else {
+										let itemCollection = game.packs.get(subTableResults.results[0].data.collection);
+										newItem = await itemCollection.getEntity(subTableResults.results[0].data.resultId);
+									}
+                }
+
                 if (!newItem || newItem === null) {
                     return;
                 }
@@ -161,12 +172,23 @@ export class LootPopulator {
 
                 if (rolltable.results[index].collection === "Item") {
                     newItem = game.items.get(rolltable.results[index].resultId);
-                }
-                else {
+                } else {
                     //Try to find it in the compendium
                     const items = game.packs.get(rolltable.results[index].data.collection);
                     newItem = await items.getEntity(rollResult.results[0].data.resultId);
                 }
+
+								if (newItem instanceof RollTable){
+									let subTableResults  = await newItem.roll();
+
+									if(subTableResults.results[index].collection === "Item"){
+										newItem = game.items.get(subTableResults.results[index].data.resultId);
+									} else {
+										let itemCollection = game.packs.get(subTableResults.results[index].data.collection);
+										newItem = await itemCollection.getEntity(subTableResults.results[index].data.resultId);
+									}
+								}
+
                 if (!newItem || newItem === null) {
                     return ui.notifications.error(this.moduleNamespace + `: No item found "${rolltable.results[index].resultId}".`);
                 }

--- a/scripts/populateLoot.js
+++ b/scripts/populateLoot.js
@@ -51,19 +51,10 @@ export class LootPopulator {
                     newItem = game.items.get(rollResult.results[0].data.resultId);
                 } else {
                     const items = game.packs.get(rollResult.results[0].data.collection);
-                    newItem = await items.getEntity(rollResult.results[0].data.resultId);
+                    newItem = await items.getDocument(rollResult.results[0].data.resultId);
                 }
 
-								if (newItem instanceof RollTable){
-									let subTableResults  = await newItem.roll();
-
-									if(subTableResults.results[0].data.collection === "Item"){
-										newItem = game.items.get(subTableResults.results[0].data.resultId);
-									} else {
-										let itemCollection = game.packs.get(subTableResults.results[0].data.collection);
-										newItem = await itemCollection.getEntity(subTableResults.results[0].data.resultId);
-									}
-                }
+								newItem = this.rollSubTables(newItem);
 
                 if (!newItem || newItem === null) {
                     return;
@@ -175,19 +166,10 @@ export class LootPopulator {
                 } else {
                     //Try to find it in the compendium
                     const items = game.packs.get(rolltable.results[index].data.collection);
-                    newItem = await items.getEntity(rollResult.results[0].data.resultId);
+                    newItem = await items.getDocument(rollResult.results[0].data.resultId);
                 }
 
-								if (newItem instanceof RollTable){
-									let subTableResults  = await newItem.roll();
-
-									if(subTableResults.results[index].collection === "Item"){
-										newItem = game.items.get(subTableResults.results[index].data.resultId);
-									} else {
-										let itemCollection = game.packs.get(subTableResults.results[index].data.collection);
-										newItem = await itemCollection.getEntity(subTableResults.results[index].data.resultId);
-									}
-								}
+								newItem = this.rollSubTables(newItem,index);
 
                 if (!newItem || newItem === null) {
                     return ui.notifications.error(this.moduleNamespace + `: No item found "${rolltable.results[index].resultId}".`);
@@ -268,6 +250,25 @@ export class LootPopulator {
 			} catch (error) {
 				return 1;
 			}
+		}
+
+		asycn _rollSubTables(item, index = 0){
+			if (item instanceof RollTable){
+				let subTableResults  = await item.roll();
+
+				if(subTableResults.results[index].data.collection === "Item"){
+					item = game.items.get(subTableResults.results[index].data.resultId);
+				} else {
+					let itemCollection = game.packs.get(subTableResults.results[index].data.collection);
+					item = await itemCollection.getDocument(subTableResults.results[index].data.resultId);
+				}
+
+				if (item instanceof RollTable){
+					item = await _getItemFromRoll(item,index);
+				}
+			}
+
+			return item;
 		}
 
 		_getSetting(setting){


### PR DESCRIPTION
Handling for the case when a roll returns a rolltable instead of an item.

Changed calls to getEntity() to getDocument() 